### PR TITLE
Fix: Use correct environment variable for Grok API key

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -132,7 +132,7 @@ If the text cannot be read, respond with:
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.GROK_API_KEY}`,
+            Authorization: `Bearer ${process.env.XAI_API_KEY}`,
           },
           body: JSON.stringify({
             model: "grok-2-vision-1212", 


### PR DESCRIPTION
The code was attempting to use `process.env.GROK_API_KEY`, but the environment variable defined in `.env` is `XAI_API_KEY`.

This commit updates `lib/actions.ts` to use the correct `XAI_API_KEY` environment variable when making API calls to Grok. This resolves the "Incorrect API key provided: un***ed" error.